### PR TITLE
Replace unique constraint with user email & phone_number unique indexes

### DIFF
--- a/server/models/contact.go
+++ b/server/models/contact.go
@@ -4,9 +4,9 @@ type Contact struct {
 	BaseModel
 	FirstName          string           `json:"first_name" validate:"required"`
 	LastName           string           `json:"last_name" validate:"required"`
-	PhoneNumber        string           `json:"phone_number" validate:"required,e164" gorm:"not null;unique"`
-	Email              string           `json:"email" validate:"required,email" gorm:"unique"`
+	PhoneNumber        string           `json:"phone_number" validate:"required,e164" gorm:"index:idx_user_id_phone_number,priority:2;not null"`
+	Email              string           `json:"email" validate:"required,email" gorm:"index:idx_user_id_email,priority:2;not null"`
+	UserID             uint             `json:"user_id" gorm:"index:idx_user_id_email,priority:1,unique;index:idx_user_id_phone_number,priority:1,unique;not null"`
 	IsEmergencyContact bool             `json:"is_emergency_contact"`
-	UserID             uint             `json:"user_id" gorm:"not null"`
 	EmergencyProbes    []EmergencyProbe `json:"emergency_probes,omitempty" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 }


### PR DESCRIPTION
Resolves #9. Allow different users to have the same contact record in their contacts, but prevent duplicate contact email/phone_number within the same user contacts list.

The added indexes i.e `idx_user_id_email` & `idx_user_id_phone_number` also make it more efficient to query for  user contacts. 