### PR TITLE
Add tests for probeScheduler

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -26,7 +26,6 @@ Available Commands:
 Flags:
       --dev       run in development mode
   -h, --help      help for kronus
-      --test      run in test mode
   -t, --toggle    Help message for toggle
   -v, --version   version for kronus
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,8 +23,7 @@ import (
 )
 
 var (
-	isDevEnv  bool
-	isTestEnv bool
+	isDevEnv bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -50,7 +49,6 @@ for users on its server.`,
 	}
 
 	cmd.PersistentFlags().BoolVarP(&isDevEnv, "dev", "", false, "run in development mode")
-	cmd.PersistentFlags().BoolVarP(&isTestEnv, "test", "", false, "run in test mode")
 
 	cmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 

--- a/server/models/base.go
+++ b/server/models/base.go
@@ -13,9 +13,9 @@ const (
 )
 
 type BaseModel struct {
-	ID        uint       `json:"id,omitempty" gorm:"primarykey"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	ID        uint      `json:"id,omitempty" gorm:"primarykey"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
 
 type Paging struct {

--- a/server/models/db_config.go
+++ b/server/models/db_config.go
@@ -55,6 +55,28 @@ func InitialiazeDb(passPhrase string, dbRootDir string, storage *gstorage.GStora
 	return nil
 }
 
+func InitializeTestDb() error {
+	var err error
+
+	db, err = gorm.Open(sqliteEncrypt.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		return err
+	}
+
+	err = db.AutoMigrate(
+		&ProbeStatus{}, &JobStatus{}, &Job{},
+		&Role{}, &Probe{}, &Contact{}, &ProbeSetting{},
+		&User{}, &EmergencyProbe{},
+	)
+	if err != nil {
+		return err
+	}
+
+	populateDBWithSeedData()
+
+	return nil
+}
+
 func DbDirectory(dbRootDir string) (string, error) {
 	dbDir := filepath.Join(dbRootDir, "db")
 

--- a/server/models/db_config.go
+++ b/server/models/db_config.go
@@ -41,18 +41,7 @@ func InitialiazeDb(passPhrase string, dbRootDir string, storage *gstorage.GStora
 		return err
 	}
 
-	err = db.AutoMigrate(
-		&ProbeStatus{}, &JobStatus{}, &Job{},
-		&Role{}, &Probe{}, &Contact{}, &ProbeSetting{},
-		&User{}, &EmergencyProbe{},
-	)
-	if err != nil {
-		return err
-	}
-
-	populateDBWithSeedData()
-
-	return nil
+	return autoMigrateAndSeedDb()
 }
 
 func InitializeTestDb() error {
@@ -63,18 +52,7 @@ func InitializeTestDb() error {
 		return err
 	}
 
-	err = db.AutoMigrate(
-		&ProbeStatus{}, &JobStatus{}, &Job{},
-		&Role{}, &Probe{}, &Contact{}, &ProbeSetting{},
-		&User{}, &EmergencyProbe{},
-	)
-	if err != nil {
-		return err
-	}
-
-	populateDBWithSeedData()
-
-	return nil
+	return autoMigrateAndSeedDb()
 }
 
 func DbDirectory(dbRootDir string) (string, error) {
@@ -113,6 +91,21 @@ func openDB(passPhrase string, dbRootDir string) error {
 	if err != nil {
 		return fmt.Errorf("failed to connect database: %v", err)
 	}
+
+	return nil
+}
+
+func autoMigrateAndSeedDb() error {
+	err := db.AutoMigrate(
+		&ProbeStatus{}, &JobStatus{}, &Job{},
+		&Role{}, &Probe{}, &Contact{}, &ProbeSetting{},
+		&User{}, &EmergencyProbe{},
+	)
+	if err != nil {
+		return err
+	}
+
+	populateDBWithSeedData()
 
 	return nil
 }

--- a/server/models/job.go
+++ b/server/models/job.go
@@ -81,10 +81,10 @@ func CreateUniqueJobByName(name string, handler string, args string) error {
 	}, Job{Name: name, JobStatusID: enqueuedJobStatus.ID}).Error
 }
 
-func LastJob(status string, claimed bool) (*Job, error) {
+func FirstJob(status string, claimed bool) (*Job, error) {
 	job := Job{}
 	err := db.Joins("INNER JOIN job_statuses ON job_statuses.id = jobs.job_status_id AND job_statuses.name = ? AND claimed = ? ",
-		status, claimed).Last(&job).Error
+		status, claimed).First(&job).Error
 	if err != nil {
 		return nil, err
 	}

--- a/server/models/probe.go
+++ b/server/models/probe.go
@@ -24,6 +24,10 @@ var ProbeStatusMapToResponse = map[string]map[string]bool{
 	BAD_PROBE:  {"no": true, "nope": true, "nah": true, "na": true, "n": true},
 }
 
+func (probe *Probe) Update(data map[string]interface{}) error {
+	return db.Model(probe).Updates(data).Error
+}
+
 func (probe *Probe) Save() error {
 	return db.Save(&probe).Error
 }

--- a/server/pbscheduler/pbscheduler.go
+++ b/server/pbscheduler/pbscheduler.go
@@ -146,7 +146,7 @@ func (pScheduler ProbeScheduler) enqueueFollowUpsForProbes(params map[string]int
 		// Follow up 3 will be @ ~8:00pm
 		//
 		// And if no respons, @ ~9:00pm send out emergency probe
-		if time.Since(*probe.UpdatedAt) < 1*time.Hour {
+		if time.Since(probe.UpdatedAt) < 1*time.Hour {
 			continue
 		}
 

--- a/server/pbscheduler/pbscheduler.go
+++ b/server/pbscheduler/pbscheduler.go
@@ -106,7 +106,7 @@ func (pScheduler ProbeScheduler) initUsersPeriodicProbes() error {
 	for _, user := range users {
 		err = pScheduler.PeriodicallyPerfomProbe(user)
 		if err != nil {
-			logg.Error(err)
+			return err
 		}
 	}
 	logg.Infof("%v liveliness probe(s) cron scheduled", len(users))

--- a/server/pbscheduler/pbscheduler_test.go
+++ b/server/pbscheduler/pbscheduler_test.go
@@ -1,7 +1,6 @@
 package pbscheduler
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -74,7 +73,6 @@ func TestScheduleProbes(t *testing.T) {
 
 	// Check that each user has 1 probe created in the database
 	for _, user := range []*models.User{testUser, testUser2} {
-		fmt.Println("Here")
 		if probes, _, err := models.FetchProbes(1, "user_id = ?", user.ID); err != nil ||
 			len(probes) != 1 {
 			t.Errorf("Expected user: %v to have probe, found none: %v", user.FirstName, err)

--- a/server/pbscheduler/pbscheduler_test.go
+++ b/server/pbscheduler/pbscheduler_test.go
@@ -1,0 +1,84 @@
+package pbscheduler
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Daskott/kronus/server/models"
+	"github.com/Daskott/kronus/server/twilio"
+	"github.com/Daskott/kronus/server/work"
+	"github.com/Daskott/kronus/shared"
+)
+
+func TestScheduleProbes(t *testing.T) {
+	models.InitializeTestDb()
+
+	everySecondCronExp := "*/1 * * * * *"
+	workerPool := work.NewWorkerAdapter("UTC", true)
+
+	pbScheduler, err := NewProbeScheduler(
+		workerPool,
+		twilio.NewClient(shared.TwilioConfig{}, "", true),
+		everySecondCronExp,
+	)
+	if err != nil {
+		t.Error(err)
+	}
+
+	testUser := &models.User{
+		FirstName:   "tony",
+		LastName:    "stark",
+		Email:       "stark@avengers.com",
+		Password:    "very-secure",
+		PhoneNumber: "+12345678900",
+	}
+
+	testUser2 := &models.User{
+		FirstName:   "spider",
+		LastName:    "man",
+		Email:       "web@avengers.com",
+		Password:    "secure???",
+		PhoneNumber: "+22345678900",
+	}
+
+	models.CreateUser(testUser)
+	if testUser.ID == 0 {
+		t.Error("Unable to create 'testUser' record")
+	}
+	testUser.UpdateProbSettings(map[string]interface{}{"active": true, "cron_expression": everySecondCronExp})
+
+	models.CreateUser(testUser2)
+	if testUser2.ID == 0 {
+		t.Error("Unable to create 'testUser2' record")
+	}
+	testUser2.UpdateProbSettings(map[string]interface{}{"active": true, "cron_expression": everySecondCronExp})
+
+	pbScheduler.ScheduleProbes()
+	workerPool.Start()
+
+	time.Sleep(3 * time.Second)
+
+	jobs, _, err := models.FetchJobs(1)
+	if err != nil {
+		t.Errorf("Failed to fetch jobs: %v", err)
+	}
+
+	// Check # of jobs created match what is expected
+	// i.e number of users with active probes + task to schedule follow up probes
+	expectedNoOfJobs := 3
+	if len(jobs) < expectedNoOfJobs {
+		t.Errorf("Expected >= %v jobs to be queued, got %v", expectedNoOfJobs, len(jobs))
+	}
+
+	// Check that each user has a probe created in the database
+	for _, user := range []*models.User{testUser, testUser2} {
+		fmt.Println("Here")
+		if probes, _, err := models.FetchProbes(1, "user_id = ?", user.ID); err != nil ||
+			len(probes) < 1 {
+			t.Errorf("Expected user: %v to have probe, found none: %v", user.FirstName, err)
+		}
+	}
+
+	workerPool.Stop()
+}

--- a/server/pbscheduler/pbscheduler_test.go
+++ b/server/pbscheduler/pbscheduler_test.go
@@ -1,6 +1,7 @@
 package pbscheduler
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -41,42 +42,175 @@ func TestScheduleProbes(t *testing.T) {
 		PhoneNumber: "+22345678900",
 	}
 
+	testUser2Contact := &models.Contact{
+		FirstName:          "doctor",
+		LastName:           "strange",
+		PhoneNumber:        "+32345678900",
+		IsEmergencyContact: true,
+		Email:              "supreme@avengers.com",
+	}
+
 	models.CreateUser(testUser)
 	if testUser.ID == 0 {
-		t.Error("Unable to create 'testUser' record")
+		t.Fatalf("Unable to create 'testUser' record")
 	}
 	testUser.UpdateProbSettings(map[string]interface{}{"active": true, "cron_expression": everySecondCronExp})
 
 	models.CreateUser(testUser2)
 	if testUser2.ID == 0 {
-		t.Error("Unable to create 'testUser2' record")
+		t.Fatalf("Unable to create 'testUser2' record")
 	}
 	testUser2.UpdateProbSettings(map[string]interface{}{"active": true, "cron_expression": everySecondCronExp})
 
+	err = testUser2.AddContact(testUser2Contact)
+	if testUser2Contact.ID == 0 {
+		t.Fatalf("Unable to create 'testUser2Contact' record, err: %v", err)
+	}
+
+	// ScheduleProbes & start job worker to process probes
 	pbScheduler.ScheduleProbes()
 	workerPool.Start()
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(4 * time.Second)
 
-	jobs, _, err := models.FetchJobs(1)
-	if err != nil {
-		t.Errorf("Failed to fetch jobs: %v", err)
+	// ---------------------------------------------------------------------------------//
+	// Test initial probe(s) are sent
+	// --------------------------------------------------------------------------------//
+
+	testCases := []struct {
+		user                 models.User
+		expectedProbeCount   int
+		expectedProbeRetries int
+		respondToProbe       bool
+	}{
+		{*testUser, 1, 0, true},
+		{*testUser2, 1, 0, false},
 	}
 
-	// Check # of jobs created >= what is expected (because of the everySecond
-	// interval, more jobs could be created)
-	// i.e atleast number of users with active probes + task to schedule follow up probes
-	expectedNoOfJobs := 3
-	if len(jobs) < expectedNoOfJobs {
-		t.Errorf("Expected >= %v jobs to be queued, got %v", expectedNoOfJobs, len(jobs))
+	for _, tcase := range testCases {
+		desc := fmt.Sprintf("User %v shoud have 1 probe recorded in db", tcase.user.FirstName)
+
+		t.Run(desc, func(t *testing.T) {
+			probes, _, err := models.FetchProbes(1, "user_id = ?", tcase.user.ID)
+			if err != nil {
+				t.Fatalf("could not fetch probes: %v", err)
+			}
+
+			if len(probes) != tcase.expectedProbeCount {
+				t.Errorf("Expected to have %v probe, found none: %v", tcase.expectedProbeCount, len(probes))
+			}
+
+			probe := probes[0]
+			if probe.RetryCount != tcase.expectedProbeRetries {
+				t.Errorf("Expected user to have %v probe retries, got %v",
+					tcase.expectedProbeRetries, probe.RetryCount)
+			}
+
+			// Setup for next test
+			if tcase.respondToProbe {
+				probe.LastResponse = "Yeah"
+				probeStatusName := probe.StatusFromLastResponse()
+				probeStatus, err := models.FindProbeStatus(probeStatusName)
+				if err != nil {
+					t.Fatalf("could not fetch probe status: %v", err)
+				}
+
+				probe.ProbeStatusID = probeStatus.ID
+				probe.Save()
+			} else {
+				// Set probe 'update_at' time to 1hr behind, to simulate 1hr of
+				// waiting with no respons fro user
+				probe.Update(map[string]interface{}{"updated_at": probe.UpdatedAt.Add(-time.Hour)})
+			}
+		})
 	}
 
-	// Check that each user has 1 probe created in the database
-	for _, user := range []*models.User{testUser, testUser2} {
-		if probes, _, err := models.FetchProbes(1, "user_id = ?", user.ID); err != nil ||
-			len(probes) != 1 {
-			t.Errorf("Expected user: %v to have probe, found none: %v", user.FirstName, err)
+	time.Sleep(2 * time.Second)
+
+	// ---------------------------------------------------------------------------------//
+	// Test followup probe(s) are sent
+	// --------------------------------------------------------------------------------//
+
+	testCases2 := []struct {
+		user                 models.User
+		expectedProbeRetries int
+	}{
+		{*testUser, 0},
+		{*testUser2, 1},
+	}
+
+	for _, tcase := range testCases2 {
+		desc := fmt.Sprintf("User %v shoud have %v followup probe recorded in db",
+			tcase.user.FirstName, tcase.expectedProbeRetries)
+
+		t.Run(desc, func(t *testing.T) {
+			probes, _, err := models.FetchProbes(1, "user_id = ?", tcase.user.ID)
+			if err != nil {
+				t.Fatalf("Failed to fetch probes %v", err)
+			}
+
+			probe := probes[0]
+			if probe.RetryCount != tcase.expectedProbeRetries {
+				t.Errorf("Expected user probe to have %v retry, got %v",
+					tcase.expectedProbeRetries, probe.RetryCount)
+			}
+
+			// Set probe retries to max_retries to simulate
+			// no reply from user with > 1 followup [setup for next test]
+			if tcase.expectedProbeRetries > 0 {
+				probe.Update(map[string]interface{}{
+					"retry_count": MAX_PROBE_RETRIES,
+					"updated_at":  probe.UpdatedAt.Add(-time.Hour)})
+			}
+		})
+	}
+
+	time.Sleep(2 * time.Second)
+
+	// ---------------------------------------------------------------------------------//
+	// Test emergency probe(s) are sent
+	// --------------------------------------------------------------------------------//
+
+	testCases3 := []struct {
+		user                         models.User
+		expectedToHaveEmergencyProbe bool
+		expectedEmergencyContact     *models.Contact
+	}{
+		{*testUser, false, nil},
+		{*testUser2, true, testUser2Contact},
+	}
+
+	for _, tcase := range testCases3 {
+		msgPatch := ""
+		if !tcase.expectedToHaveEmergencyProbe {
+			msgPatch = " NOT"
 		}
+
+		desc := fmt.Sprintf("User %v shoud%v have emergency probe recorded in db",
+			tcase.user.FirstName, msgPatch)
+
+		t.Run(desc, func(t *testing.T) {
+			probes, _, err := models.FetchProbes(1, "user_id = ?", tcase.user.ID)
+			if err != nil {
+				t.Fatalf("Failed to fetch probes %v", err)
+			}
+
+			probe := probes[0]
+			if !tcase.expectedToHaveEmergencyProbe && probe.EmergencyProbe != nil {
+				t.Fatalf("Expected user to have emergency probe recorded, found: %v", probe.EmergencyProbe)
+			}
+
+			if tcase.expectedToHaveEmergencyProbe {
+				if probe.EmergencyProbe == nil {
+					t.Fatalf("Expected user to have emergency probe recorded, found none. Probe: %v", probe)
+				}
+
+				if probe.EmergencyProbe.ContactID != tcase.expectedEmergencyContact.ID {
+					t.Fatalf("Expected emergency probe to be sent to contact with ID=%v, got sent to contact with ID=%v",
+						tcase.expectedEmergencyContact.ID, probe.EmergencyProbe.ContactID)
+				}
+			}
+		})
 	}
 
 	workerPool.Stop()

--- a/server/pbscheduler/pbscheduler_test.go
+++ b/server/pbscheduler/pbscheduler_test.go
@@ -64,18 +64,19 @@ func TestScheduleProbes(t *testing.T) {
 		t.Errorf("Failed to fetch jobs: %v", err)
 	}
 
-	// Check # of jobs created match what is expected
-	// i.e number of users with active probes + task to schedule follow up probes
+	// Check # of jobs created >= what is expected (because of the everySecond
+	// interval, more jobs could be created)
+	// i.e atleast number of users with active probes + task to schedule follow up probes
 	expectedNoOfJobs := 3
 	if len(jobs) < expectedNoOfJobs {
 		t.Errorf("Expected >= %v jobs to be queued, got %v", expectedNoOfJobs, len(jobs))
 	}
 
-	// Check that each user has a probe created in the database
+	// Check that each user has 1 probe created in the database
 	for _, user := range []*models.User{testUser, testUser2} {
 		fmt.Println("Here")
 		if probes, _, err := models.FetchProbes(1, "user_id = ?", user.ID); err != nil ||
-			len(probes) < 1 {
+			len(probes) != 1 {
 			t.Errorf("Expected user: %v to have probe, found none: %v", user.FirstName, err)
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -65,13 +65,13 @@ func Start(configArg *shared.ServerConfig, devMode bool) {
 	authKeyPair, err = key.NewKeyPairFromRSAPrivateKeyPem(config.Kronus.PrivateKeyPem)
 	fatalOnError(err)
 
-	workerPool = work.NewWorkerAdapter(config.Kronus.Cron.TimeZone)
+	workerPool = work.NewWorkerAdapter(config.Kronus.Cron.TimeZone, false)
 	registerJobHandlers(workerPool)
 	enqueueJobs(workerPool)
 
 	twilioClient = twilio.NewClient(config.Twilio, config.Kronus.PublicUrl, devMode)
 
-	probeScheduler, err = pbscheduler.NewProbeScheduler(workerPool, twilioClient)
+	probeScheduler, err = pbscheduler.NewProbeScheduler(workerPool, twilioClient, "*/1 * * * *")
 	fatalOnError(err)
 	probeScheduler.ScheduleProbes()
 

--- a/server/work/worker.go
+++ b/server/work/worker.go
@@ -83,7 +83,7 @@ func (w *worker) loop() {
 			logg.Infof("Stopping worker %s", w.id)
 			return
 		case <-rateLimiter.C:
-			currentJob, err = models.LastJob(models.ENQUEUED_JOB, false)
+			currentJob, err = models.FirstJob(models.ENQUEUED_JOB, false)
 			if err != nil {
 				if errors.Is(err, gorm.ErrRecordNotFound) {
 					// If no job found, slowly increase the wait time between each job fetch

--- a/server/work/worker_pool.go
+++ b/server/work/worker_pool.go
@@ -26,7 +26,7 @@ func newWorkerPool(concurrency int) *workerPool {
 	}
 
 	for i := 0; i < concurrency; i++ {
-		wp.workers = append(wp.workers, newWorker([]int64{0, 10, 30, 60, 80, 100, 120}))
+		wp.workers = append(wp.workers, newWorker([]int64{0, 1, 2, 5, 15, 30}))
 	}
 
 	return &wp


### PR DESCRIPTION
Resolves #24 

This includes:
- Tests for the whole `probeScheduler.ScheduleProbes()` workflow:
   - It tests that initial probes are scheduled & triggered
   - It tests that followup/emergency probes are also scheduled & triggered if necessary
- Refactors
  - `NewProbeScheduler` now accepts `followProbesCronSchedule` - to set how often the followup probe task is run
  - `NewWorkerAdapter` now accepts `useCronParserWithSeconds` - to determine wether or not to accept cron expressions with `6`(with seconds)/ `5` fields.
  - Use queue not stack for processing jobs
- Other
  - Better error handling for scheduling user probes
  - Remove `--test` flag