### PR TITLE
Add ability to create probe via sms

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -243,7 +243,9 @@ kronus server --config=config.yml
           "updated_at": "2022-01-10T20:33:16.828639-07:00",
           "user_id": 1,
           "active": true,
-          "cron_expression": "0 18 * * */1"
+          "cron_expression": "0 18 * * */1",
+          "max_retries": 3,
+          "wait_time_in_minutes": 60
       }
   }
   ```

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -14,6 +14,7 @@ Its key features are:
   to see the `status` of the last probe. And based on that, do whatever the
   developer wants.
 
+### CLI Usage
 ```
 Usage:
   kronus [command]
@@ -30,7 +31,22 @@ Flags:
   -v, --version   version for kronus
 
 Use "kronus [command] --help" for more information about a command.
-  ```
+```
+
+### SMS Usage  
+In addition to responding to probe via sms, few commands are
+supported for numbers on the server
+```
+Usage:
+  [command]
+
+Available Commands:
+	help    Help about any command
+	probe   Ask kronus to check on you in a couple minutes
+	ping    Health check for the serve
+
+Use "[command] --help" for more information about a command.
+```
 
 ## Dependencies
 - Install [Go](https://golang.org/dl/)

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.9.0
+	github.com/stretchr/testify v1.7.0
 	github.com/twilio/twilio-go v0.19.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5
@@ -21,6 +22,7 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0 // indirect
 	github.com/goccy/go-json v0.4.8 // indirect
 	github.com/golang/mock v1.6.0 // indirect
@@ -30,10 +32,12 @@ require (
 	github.com/lestrrat-go/iter v1.0.1 // indirect
 	github.com/lestrrat-go/option v1.0.0 // indirect
 	github.com/mutecomm/go-sqlcipher/v4 v4.4.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 require (

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -209,8 +209,12 @@ func updateProbeSettingsHandler(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	removeUnknownFields(params,
-		map[string]bool{"active": true, "cron_expression": true, "max_retries": true, "wait_time_in_minutes": true})
+	removeUnknownFields(params, map[string]bool{
+		"active":               true,
+		"cron_expression":      true,
+		"max_retries":          true,
+		"wait_time_in_minutes": true,
+	})
 	if len(params) <= 0 {
 		writeResponse(rw,
 			ResponsePayload{Errors: []string{"valid fields required"}},

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -209,13 +209,26 @@ func updateProbeSettingsHandler(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	removeUnknownFields(params, map[string]bool{"active": true, "cron_expression": true})
+	removeUnknownFields(params,
+		map[string]bool{"active": true, "cron_expression": true, "max_retries": true, "wait_time_in_minutes": true})
 	if len(params) <= 0 {
 		writeResponse(rw,
 			ResponsePayload{Errors: []string{"valid fields required"}},
 			http.StatusBadRequest,
 		)
 		return
+	}
+
+	if params["max_retries"] != nil {
+		if err := validate.Var(params["max_retries"], "lte=6"); err != nil {
+			errs = append(errs, "valid 'max_retries' field is required. And it must be <= 6")
+		}
+	}
+
+	if params["wait_time_in_minutes"] != nil {
+		if err := validate.Var(params["wait_time_in_minutes"], "gte=5,lte=120"); err != nil {
+			errs = append(errs, "valid 'wait_time_in_minutes' field is required. And it must be >=5 and <= 120")
+		}
 	}
 
 	if _, ok := params["active"].(bool); params["active"] != nil && !ok {

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -360,10 +360,14 @@ func handleHelpCmd(input string) ([]byte, error) {
 		return xml.Marshal(&TwilioSmsResponse{Message: outputBuffer.String()})
 	}
 
-	res := `
+	res := `Usage:
+[command]
+
 Available Commands:
-	help        Help about any command
-	probe       Ask kronus to check on you in a couple minutes
-	ping    	Health check for the server`
+  help    Help about any command
+  probe   Ask kronus to check on you in a couple minutes
+  ping    Health check for the serve
+
+Use "[command] --help" for more information about a command.`
 	return xml.Marshal(&TwilioSmsResponse{Message: res})
 }

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -329,8 +329,8 @@ func handleDynamicProbeCmd(user *models.User, input string) ([]byte, error) {
 	}
 
 	err = workerPool.PerformIn(*inPtr*60, work.JobParams{
-		Name:    "send_liveliness_probe",
-		Handler: "send_liveliness_probe",
+		Name:    pbscheduler.SEND_DYNAMIC_PROBE_HANDLER,
+		Handler: pbscheduler.SEND_DYNAMIC_PROBE_HANDLER,
 		Args: map[string]interface{}{
 			"first_name":           user.FirstName,
 			"last_name":            user.LastName,

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -240,12 +240,12 @@ func handleProbeMsgReply(user models.User, message string) ([]byte, error) {
 			return []byte("<Response />"), nil
 		}
 
-		return []byte{}, err
+		return nil, err
 	}
 
 	pendingProbe, err := probe.IsPending()
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	// If no pending probe - do nothing
@@ -265,7 +265,7 @@ func handleProbeMsgReply(user models.User, message string) ([]byte, error) {
 
 	probeStatus, err := models.FindProbeStatus(probeStatusName)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	probe.ProbeStatusID = probeStatus.ID
@@ -287,7 +287,7 @@ func handleProbeMsgReply(user models.User, message string) ([]byte, error) {
 		})
 
 		if err != nil {
-			return []byte{}, err
+			return nil, err
 		}
 	}
 
@@ -343,7 +343,7 @@ func handleDynamicProbeCmd(user *models.User, input string) ([]byte, error) {
 		},
 	})
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	return xml.Marshal(&TwilioSmsResponse{Message: fmt.Sprintf(

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -321,6 +321,13 @@ func handleDynamicProbeCmd(user *models.User, input string) ([]byte, error) {
 		return xml.Marshal(&TwilioSmsResponse{Message: outputBuffer.String()})
 	}
 
+	if _, err := user.EmergencyContact(); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return xml.Marshal(&TwilioSmsResponse{Message: "An emergency contact is required to use the 'probe' cmd"})
+		}
+		return []byte{}, err
+	}
+
 	err = workerPool.PerformIn(*inPtr*60, work.JobParams{
 		Name:    "send_liveliness_probe",
 		Handler: "send_liveliness_probe",

--- a/server/models/probe.go
+++ b/server/models/probe.go
@@ -17,6 +17,10 @@ type Probe struct {
 	UserID         uint            `json:"user_id" gorm:"not null"`
 	ProbeStatusID  uint            `json:"probe_status_id"`
 	ProbeStatus    *ProbeStatus    `json:"status"`
+
+	// TODO: Remove defaults later & set fields to "not null"
+	MaxRetries        int `json:"max_retries" gorm:"default:3"`
+	WaitTimeInMinutes int `json:"wait_time_in_minutes" gorm:"default:60"`
 }
 
 var ProbeStatusMapToResponse = map[string]map[string]bool{
@@ -136,7 +140,7 @@ func FindProbe(id interface{}) (*Probe, error) {
 	return &probe, nil
 }
 
-func CreateProbe(userID interface{}) error {
+func CreateProbe(userID interface{}, waitTimeInMinutes, maxRetries int) error {
 	currentTime := time.Now()
 	pendingProbeStatus := ProbeStatus{}
 	err := db.Where(&ProbeStatus{Name: "pending"}).Find(&pendingProbeStatus).Error
@@ -145,10 +149,12 @@ func CreateProbe(userID interface{}) error {
 	}
 
 	return db.Model(&Probe{}).Create(map[string]interface{}{
-		"user_id":         userID,
-		"probe_status_id": pendingProbeStatus.ID,
-		"created_at":      currentTime,
-		"updated_at":      currentTime,
+		"user_id":              userID,
+		"probe_status_id":      pendingProbeStatus.ID,
+		"wait_time_in_minutes": waitTimeInMinutes,
+		"max_retries":          maxRetries,
+		"created_at":           currentTime,
+		"updated_at":           currentTime,
 	}).Error
 }
 

--- a/server/models/probe_setting.go
+++ b/server/models/probe_setting.go
@@ -5,7 +5,9 @@ const DEFAULT_PROBE_CRON_EXPRESSION = "0 18 * * 3"
 
 type ProbeSetting struct {
 	BaseModel
-	UserID         uint   `json:"user_id" gorm:"not null;unique"`
-	Active         bool   `json:"active" gorm:"default:false"`
-	CronExpression string `json:"cron_expression" gorm:"not null"`
+	UserID            uint   `json:"user_id" gorm:"not null;unique"`
+	Active            bool   `json:"active" gorm:"default:false"`
+	CronExpression    string `json:"cron_expression" gorm:"not null"`
+	MaxRetries        int    `json:"max_retries" gorm:"default:3"`
+	WaitTimeInMinutes int    `json:"wait_time_in_minutes" gorm:"default:60"`
 }

--- a/server/pbscheduler/pbscheduler.go
+++ b/server/pbscheduler/pbscheduler.go
@@ -201,6 +201,10 @@ func (pScheduler ProbeScheduler) sendLivelinessProbe(params map[string]interface
 		return err
 	}
 
+	// TODO: How to handle this ? Dynamic probe should still be run even if
+	// liveliness probe is in-active
+	// OR
+	// Have separate function to just send probe
 	if !user.ProbeSettings.Active {
 		logg.Infof("skipping liveliness probe for userID=%v, it's currently disabled", params["user_id"])
 		return nil
@@ -212,6 +216,7 @@ func (pScheduler ProbeScheduler) sendLivelinessProbe(params map[string]interface
 		return err
 	}
 
+	// TODO: How to handle this ? Should probe run if one is still on-going
 	if lastProbe != nil {
 		isPendingProbe, err := lastProbe.IsPending()
 		if err != nil {
@@ -238,11 +243,11 @@ func (pScheduler ProbeScheduler) sendLivelinessProbe(params map[string]interface
 	waitTimeInMinutes := user.ProbeSettings.WaitTimeInMinutes
 	maxRetries := user.ProbeSettings.MaxRetries
 
-	if val, err := strconv.Atoi(fmt.Sprint(params["wait_time_in_minutes"])); err != nil {
+	if val, err := strconv.Atoi(fmt.Sprint(params["wait_time_in_minutes"])); err == nil {
 		waitTimeInMinutes = val
 	}
 
-	if val, err := strconv.Atoi(fmt.Sprint(params["max_retries"])); err != nil {
+	if val, err := strconv.Atoi(fmt.Sprint(params["max_retries"])); err == nil {
 		maxRetries = val
 	}
 

--- a/server/pbscheduler/pbscheduler_test.go
+++ b/server/pbscheduler/pbscheduler_test.go
@@ -16,7 +16,8 @@ func TestScheduleProbes(t *testing.T) {
 	models.InitializeTestDb()
 
 	everySecondCronExp := "*/1 * * * * *"
-	workerPool := work.NewWorkerAdapter("UTC", true)
+	workerPool, err := work.NewWorkerAdapter("UTC", true)
+	assert.Nil(t, err)
 
 	pbScheduler, err := NewProbeScheduler(
 		workerPool,

--- a/server/pbscheduler/pbscheduler_test.go
+++ b/server/pbscheduler/pbscheduler_test.go
@@ -159,7 +159,7 @@ func TestScheduleProbes(t *testing.T) {
 			// no reply from user with > 1 followup [setup for next test]
 			if tcase.expectedProbeRetries > 0 {
 				probe.Update(map[string]interface{}{
-					"retry_count": MAX_PROBE_RETRIES,
+					"retry_count": probe.MaxRetries,
 					"updated_at":  probe.UpdatedAt.Add(-time.Hour)})
 			}
 		})

--- a/server/server.go
+++ b/server/server.go
@@ -65,7 +65,9 @@ func Start(configArg *shared.ServerConfig, devMode bool) {
 	authKeyPair, err = key.NewKeyPairFromRSAPrivateKeyPem(config.Kronus.PrivateKeyPem)
 	fatalOnError(err)
 
-	workerPool = work.NewWorkerAdapter(config.Kronus.Cron.TimeZone, false)
+	workerPool, err = work.NewWorkerAdapter(config.Kronus.Cron.TimeZone, false)
+	fatalOnError(err)
+
 	registerJobHandlers(workerPool)
 	enqueueJobs(workerPool)
 

--- a/server/work/adapter.go
+++ b/server/work/adapter.go
@@ -68,6 +68,19 @@ func (adapter *WorkerPoolAdapter) Perform(job JobParams) error {
 	return nil
 }
 
+// PerformIn sends a job to the 'scheduled' queue
+// to be executed as soon as 'secondsInFuture' has elapsed
+func (adapter *WorkerPoolAdapter) PerformIn(secondsInFuture int, job JobParams) error {
+	logg.Infof("Scheduling job: %v, to run in %v seconds", job, secondsInFuture)
+
+	err := adapter.pool.enqueueIn(secondsInFuture, job)
+	if err != nil {
+		return fmt.Errorf("error scheduling job: %v, %v", job, err)
+	}
+
+	return nil
+}
+
 // PeriodicallyPerform adds a job to the queue periodically (to be executed),
 // based on the 'cronExpression' expression provided.
 //

--- a/server/work/adapter.go
+++ b/server/work/adapter.go
@@ -20,12 +20,17 @@ type WorkerPoolAdapter struct {
 	useCronParserWithSeconds bool
 }
 
-func NewWorkerAdapter(timeZoneArg string, useCronParserWithSeconds bool) *WorkerPoolAdapter {
+func NewWorkerAdapter(timeZoneArg string, useCronParserWithSeconds bool) (*WorkerPoolAdapter, error) {
+	workerPool, err := newWorkerPool(MAX_CONCURRENCY)
+	if err != nil {
+		return nil, err
+	}
+
 	return &WorkerPoolAdapter{
 		cronScheduler:            cron.NewCronScheduler(timeZoneArg),
-		pool:                     *newWorkerPool(MAX_CONCURRENCY),
+		pool:                     *workerPool,
 		useCronParserWithSeconds: useCronParserWithSeconds,
-	}
+	}, nil
 }
 
 // Start starts the cron scheduler & worker pool

--- a/server/work/adapter_test.go
+++ b/server/work/adapter_test.go
@@ -12,7 +12,9 @@ import (
 func TestPerformIn(t *testing.T) {
 	models.InitializeTestDb()
 
-	workerPool := NewWorkerAdapter("UTC", true)
+	workerPool, err := NewWorkerAdapter("UTC", true)
+	assert.Nil(t, err)
+
 	outputBuffer := new(bytes.Buffer)
 	outStr := outputBuffer.String()
 
@@ -23,7 +25,7 @@ func TestPerformIn(t *testing.T) {
 	}
 	workerPool.Register("write_to_buffer", writeToBuffer)
 
-	err := workerPool.PerformIn(2, JobParams{
+	err = workerPool.PerformIn(2, JobParams{
 		Name:    "write_to_buffer",
 		Handler: "write_to_buffer",
 		Args:    map[string]interface{}{},

--- a/server/work/adapter_test.go
+++ b/server/work/adapter_test.go
@@ -1,0 +1,46 @@
+package work
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/Daskott/kronus/server/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPerformIn(t *testing.T) {
+	models.InitializeTestDb()
+
+	workerPool := NewWorkerAdapter("UTC", true)
+	outputBuffer := new(bytes.Buffer)
+	outStr := outputBuffer.String()
+
+	// Register job function
+	writeToBuffer := func(m map[string]interface{}) error {
+		_, err := outputBuffer.WriteString("Hello")
+		return err
+	}
+	workerPool.Register("write_to_buffer", writeToBuffer)
+
+	err := workerPool.PerformIn(2, JobParams{
+		Name:    "write_to_buffer",
+		Handler: "write_to_buffer",
+		Args:    map[string]interface{}{},
+	})
+	assert.Nil(t, err)
+	assert.Empty(t, outStr, "Expected outputBuffer to be empty")
+
+	// Wait until time to perform job has elapsed
+	time.Sleep(3 * time.Second)
+
+	workerPool.Start()
+
+	// Wait for job to be processed
+	time.Sleep(2 * time.Second)
+
+	workerPool.Stop()
+
+	outStr = outputBuffer.String()
+	assert.Equal(t, "Hello", outStr, "Expected job to write to outputBuffer")
+}

--- a/server/work/requeuer.go
+++ b/server/work/requeuer.go
@@ -59,8 +59,6 @@ func (r *requeuer) loop() {
 
 			// If no job found, sleep for 'sleepBackOff' seconds
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				// TODO: Remove this log
-				r.logInfof("no job in '%s' - sleep for %v seconds", r.fromQueue, sleepBackOff)
 				rateLimiter.Reset(time.Duration(sleepBackOff) * time.Second)
 				continue
 			}
@@ -84,7 +82,7 @@ func (r *requeuer) nextJob() (*models.Job, error) {
 	if r.fromQueue == models.IN_PROGRESS_JOB {
 		return models.LastJobLastUpdated(10, models.IN_PROGRESS_JOB)
 	}
-	return models.FirstScheduledJob()
+	return models.FirstScheduledJobToBeQueued()
 }
 
 func (r *requeuer) requeue(job *models.Job) {

--- a/server/work/requeuer.go
+++ b/server/work/requeuer.go
@@ -2,6 +2,7 @@ package work
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/Daskott/kronus/colors"
@@ -10,13 +11,21 @@ import (
 )
 
 type requeuer struct {
-	stopChan chan struct{}
+	fromQueue string
+	stopChan  chan struct{}
 }
 
-func newRequeuer() *requeuer {
-	return &requeuer{
-		stopChan: make(chan struct{}),
+var supportedQueues = map[string]bool{models.IN_PROGRESS_JOB: true, models.SCHEDULED_JOB: true}
+
+func newRequeuer(fromQueue string) (*requeuer, error) {
+	if !supportedQueues[fromQueue] {
+		return nil, fmt.Errorf("%v is not a supported queue, must be in %v", fromQueue, supportedQueues)
 	}
+
+	return &requeuer{
+		fromQueue: fromQueue,
+		stopChan:  make(chan struct{}),
+	}, nil
 }
 
 // start starts the requeuer loop that pulls jobs from 'in-progress'
@@ -30,26 +39,29 @@ func (r *requeuer) stop() {
 }
 
 func (r *requeuer) loop() {
-	var stuckJob *models.Job
+	var job *models.Job
 	var err error
 
-	sleepBackOff := 30
+	// At some point we may need an expnential back-off,
+	// but for now keep it simple
+	sleepBackOff := 5
 	rateLimiter := time.NewTicker(DefaultTickerDuration)
 	defer rateLimiter.Stop()
 
-	logg.Infof("Starting job requeuer")
+	logg.Infof("Starting %s job requeuer", r.fromQueue)
 	for {
 		select {
 		case <-r.stopChan:
-			logg.Infof("Stopping job requeuer")
+			logg.Infof("Stopping %s job requeuer", r.fromQueue)
 			return
 		case <-rateLimiter.C:
-			stuckJob, err = models.LastJobLastUpdated(30, models.IN_PROGRESS_JOB)
+			job, err = r.nextJob()
 
-			// If no stuck job found, sleep for 'sleepBackOff' minutes
+			// If no job found, sleep for 'sleepBackOff' seconds
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				r.logInfof("no stuck job in in-progress - sleep for %v minutes", sleepBackOff)
-				rateLimiter.Reset(time.Duration(sleepBackOff) * time.Minute)
+				// TODO: Remove this log
+				r.logInfof("no job in '%s' - sleep for %v seconds", r.fromQueue, sleepBackOff)
+				rateLimiter.Reset(time.Duration(sleepBackOff) * time.Second)
 				continue
 			}
 
@@ -60,12 +72,19 @@ func (r *requeuer) loop() {
 			}
 
 			r.logInfof("fetched job with id=%v, status_id=%v, job.claimed=%v",
-				stuckJob.ID, stuckJob.JobStatusID, stuckJob.Claimed)
+				job.ID, job.JobStatusID, job.Claimed)
 
-			r.requeue(stuckJob)
+			r.requeue(job)
 			rateLimiter.Reset(DefaultTickerDuration)
 		}
 	}
+}
+
+func (r *requeuer) nextJob() (*models.Job, error) {
+	if r.fromQueue == models.IN_PROGRESS_JOB {
+		return models.LastJobLastUpdated(10, models.IN_PROGRESS_JOB)
+	}
+	return models.FirstScheduledJob()
 }
 
 func (r *requeuer) requeue(job *models.Job) {
@@ -88,11 +107,11 @@ func (r *requeuer) requeue(job *models.Job) {
 }
 
 func (r *requeuer) logInfof(template string, args ...interface{}) {
-	prefix := colors.Yellow("[job requeuer] ")
+	prefix := colors.Yellow(fmt.Sprintf("[%s job requeuer] ", r.fromQueue))
 	logg.Infof(prefix+template, args...)
 }
 
 func (r *requeuer) logError(args ...interface{}) {
-	prefix := colors.Red("[job requeuer] ")
+	prefix := colors.Red(fmt.Sprintf("[%s job requeuer] ", r.fromQueue))
 	logg.Errorf(prefix, args...)
 }

--- a/server/work/worker_pool.go
+++ b/server/work/worker_pool.go
@@ -20,9 +20,17 @@ type workerPool struct {
 	started     bool
 }
 
-func newWorkerPool(concurrency int) *workerPool {
-	retrier, _ := newRequeuer(models.IN_PROGRESS_JOB)
-	scheduler, _ := newRequeuer(models.SCHEDULED_JOB)
+func newWorkerPool(concurrency int) (*workerPool, error) {
+	retrier, err := newRequeuer(models.IN_PROGRESS_JOB)
+	if err != nil {
+		return nil, err
+	}
+
+	scheduler, err := newRequeuer(models.SCHEDULED_JOB)
+	if err != nil {
+		return nil, err
+	}
+
 	wp := workerPool{
 		handlers:    make(map[string]Handler),
 		concurrency: concurrency,
@@ -34,7 +42,7 @@ func newWorkerPool(concurrency int) *workerPool {
 		wp.workers = append(wp.workers, newWorker([]int64{0, 1, 2, 5, 15, 30}))
 	}
 
-	return &wp
+	return &wp, nil
 }
 
 // registerHandler binds a name to a job handler for all workers in pool

--- a/server/work/worker_pool_test.go
+++ b/server/work/worker_pool_test.go
@@ -11,8 +11,10 @@ import (
 func TestEnqueueIn(t *testing.T) {
 	models.InitializeTestDb()
 
-	workerPool := newWorkerPool(MAX_CONCURRENCY)
-	err := workerPool.enqueueIn(1, JobParams{
+	workerPool, err := newWorkerPool(MAX_CONCURRENCY)
+	assert.Nil(t, err)
+
+	err = workerPool.enqueueIn(1, JobParams{
 		Name:    "suits",
 		Handler: "donna",
 		Args: map[string]interface{}{

--- a/server/work/worker_pool_test.go
+++ b/server/work/worker_pool_test.go
@@ -1,0 +1,36 @@
+package work
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Daskott/kronus/server/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnqueueIn(t *testing.T) {
+	models.InitializeTestDb()
+
+	workerPool := newWorkerPool(MAX_CONCURRENCY)
+	err := workerPool.enqueueIn(1, JobParams{
+		Name:    "suits",
+		Handler: "donna",
+		Args: map[string]interface{}{
+			"first_name": "mike",
+			"last_name":  "ross",
+		},
+	})
+	assert.Nil(t, err)
+
+	// At some point we need to be able to
+	// mock the current time, instead of stopping the
+	// process. For now, keep it simple
+	time.Sleep(1 * time.Second)
+
+	// Make sure the correct job is created & scheduled to be run
+	job, err := models.FirstScheduledJobToBeQueued()
+	assert.Nil(t, err)
+	assert.Equal(t, "suits", job.Name, "The job name should match the expected job name")
+	assert.Contains(t, job.Args, "mike", "Should contain the correct arg values")
+	assert.Equal(t, models.SCHEDULED_JOB, job.JobStatus.Name, "The job should be in scheduled queue")
+}


### PR DESCRIPTION
Resolves #13 
This PR does the following:
- Adds `EnqueueIn` & `PerformIn` functions to `workerPool` to add the ability to set dynamic probes
- Added support for `probe` & `help` command via sms
- Cleaned up sms handler for webhook
- Added  & updated tests